### PR TITLE
Add midpoint method and a test

### DIFF
--- a/Geometry.jl
+++ b/Geometry.jl
@@ -72,5 +72,11 @@ function isRectangular(polygon::Polygon)
     false
 end
 
+"""
+midpoint(p::Polyon)
+calculates the midpoint of the polygon.
+"""
+midpoint(p::Polygon) = Point2D(mean(map(pt -> pt.x, p.pts)), mean(map(pt -> pt.y, p.pts)))
+
+
 end # End of module Geometry
- 

--- a/geometry-test.jl
+++ b/geometry-test.jl
@@ -14,4 +14,8 @@ perimeter(triangle), perimeter(rectangle)
 
 # Test the distance function
 distance(p1, p2), distance(Point3D{Float64}(1.0, 2.0, 3.0), Point3D{Float64}(4.0, 5.0, 6.0))
- 
+
+@testset "Midpoint caclulations" begin
+  @test midpoint(triangle) == Point2D(1/3,1/3)
+  @test midpoint(rectangle) == Point2D(0.5,1)
+end


### PR DESCRIPTION
This adds a midpoint method for a Polygon and provides a test for the midpoint of a triangle and a rectangle.